### PR TITLE
Add lkvm-static and libfdt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 $(shell mkdir -p rootfsimg/build)
 
-APPS = hello busybox before_workload trap qemu_trap
+APPS = hello busybox before_workload trap qemu_trap dtc lkvm-static
 APPS_DIR = $(addprefix apps/, $(APPS))
 
 .PHONY: rootfsimg $(APPS_DIR) clean

--- a/apps/busybox/Makefile
+++ b/apps/busybox/Makefile
@@ -4,7 +4,6 @@ include $(RISCV_ROOTFS_HOME)/Makefile.app
 
 REPO_PATH = repo
 $(REPO_PATH):
-	mkdir -p $@
 	git clone --depth 1 -b 1_32_stable https://github.com/mirror/busybox.git $@
 	cp config $@/.config
 

--- a/apps/dtc/Makefile
+++ b/apps/dtc/Makefile
@@ -1,0 +1,18 @@
+NAME = dtc
+
+include $(RISCV_ROOTFS_HOME)/Makefile.app
+
+ARCH ?= riscv
+CROSS_COMPILE ?= riscv64-unknown-linux-gnu-
+CC := $(CROSS_COMPILE)gcc -mabi=lp64d -march=rv64gc
+TRIPLET := $(shell $(CC) -dumpmachine)
+
+REPO_PATH = repo
+$(REPO_PATH):
+	git clone --depth 1 -b v1.7.2 https://git.kernel.org/pub/scm/utils/dtc/dtc.git $@
+
+$(APP): | $(REPO_PATH)
+	$(MAKE) -C $(REPO_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) CC="$(CC)" NO_PYTHON=1 NO_YAML=1 DESTDIR=$(APP) PREFIX=/usr LIBDIR=/usr/lib64/lp64d  install-lib install-includes
+
+clean-repo:
+	$(MAKE) -C $(REPO_PATH) clean

--- a/apps/lkvm-static/Makefile
+++ b/apps/lkvm-static/Makefile
@@ -1,0 +1,25 @@
+NAME = lkvm-static
+
+include $(RISCV_ROOTFS_HOME)/Makefile.app
+
+LIBFDT_DIR=$(RISCV_ROOTFS_HOME)/apps/dtc/build/dtc/usr/lib64/lp64d
+LIBFDT=$(LIBFDT_DIR)/libfdt.a
+
+.PHONY: check-libfdt
+check-libfdt:
+	@if [ ! -f "$(LIBFDT)" ]; then \
+		echo "Error: Dependency file '$(LIBFDT)' is missing. Please build it first."; \
+		exit 1; \
+	fi
+
+REPO_PATH = repo
+$(REPO_PATH):
+	git clone --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git $@
+
+$(APP): check-libfdt | $(REPO_PATH)
+	$(MAKE) LIBFDT_DIR=$(LIBFDT_DIR) -C $(REPO_PATH) lkvm-static
+	$(CROSS_COMPILE)strip $(REPO_PATH)/lkvm-static
+	ln -sf $(abspath $(REPO_PATH)/lkvm-static) $@
+
+clean-repo:
+	$(MAKE) -C $(REPO_PATH) clean

--- a/rootfsimg/fstab
+++ b/rootfsimg/fstab
@@ -1,0 +1,5 @@
+# /etc/fstab: static file system information.
+#
+# <file system>	<mount point>	<type>	<options>	<dump>	<pass>
+proc		/proc		proc	defaults	0	0
+sysfs		/sys		sysfs	defaults	0	0


### PR DESCRIPTION
- delete manually create dir operation, it will cause `make` cannot check dependencies correctly when `git clone` failed