### PR TITLE
checkpoint: support large workload from disk

### DIFF
--- a/rootfsimg/init-disk.sh
+++ b/rootfsimg/init-disk.sh
@@ -1,0 +1,35 @@
+#!/bin/busybox sh
+
+set -e
+
+echo "Init started with PID: $$"
+
+if [ "$$" -ne 1 ]; then
+  echo "Error: /init must be PID 1"
+  exit 1
+fi
+
+/bin/busybox --install -s
+
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev
+mkdir -p /run
+mount -t tmpfs tmpfs /run
+
+mkdir /ram_root
+mount -t tmpfs -o size=6G tmpfs /ram_root
+
+echo "Move disk fs into memory"
+mount /dev/vda /mnt 
+cp /mnt/* /ram_root/
+umount /mnt
+
+echo "Chroot into disk fs in memory"
+
+mount --bind /dev /ram_root/dev
+mount -t sysfs sysfs /ram_root/sys
+mount -t sysfs proc /ram_root/proc
+mount -t tmpfs tmpfs /ram_root/run
+
+chroot /ram_root /bin/bash

--- a/rootfsimg/initramfs-disk.txt
+++ b/rootfsimg/initramfs-disk.txt
@@ -1,0 +1,34 @@
+dir /bin 755 0 0
+dir /etc 755 0 0
+dir /dev 755 0 0
+dir /lib 755 0 0
+dir /proc 755 0 0
+dir /sbin 755 0 0
+dir /sys 755 0 0
+dir /tmp 755 0 0
+dir /usr 755 0 0
+dir /mnt 755 0 0
+dir /usr/bin 755 0 0
+dir /usr/lib 755 0 0
+dir /usr/sbin 755 0 0
+dir /var 755 0 0
+dir /var/tmp 755 0 0
+dir /root 755 0 0
+dir /var/log 755 0 0
+
+nod /dev/console 644 0 0 c 5 1
+nod /dev/null 644 0 0 c 1 3
+
+# libraries
+file /lib/ld-linux-riscv64-lp64d.so.1 ${RISCV}/sysroot/lib/ld-linux-riscv64-lp64d.so.1 755 0 0
+file /lib/libc.so.6 ${RISCV}/sysroot/lib/libc.so.6 755 0 0
+file /lib/libresolv.so.2 ${RISCV}/sysroot/lib/libresolv.so.2 755 0 0
+file /lib/libm.so.6 ${RISCV}/sysroot/lib/libm.so.6 755 0 0
+file /lib/libdl.so.2 ${RISCV}/sysroot/lib/libdl.so.2 755 0 0
+file /lib/libpthread.so.0 ${RISCV}/sysroot/lib/libpthread.so.0 755 0 0
+
+# busybox
+file /bin/busybox ${RISCV_ROOTFS_HOME}/rootfsimg/build/busybox 755 0 0
+file /etc/init ${RISCV_ROOTFS_HOME}/rootfsimg/init-disk.sh 755 0 0
+slink /bin/sh /bin/busybox 755 0 0
+slink /init /etc/init 755 0 0


### PR DESCRIPTION
Add a new initramfs-disk.txt which uses init-disk.sh as /init to automatically mount virtio disk, copy env into ram disk, and chroot into disk env in mem.